### PR TITLE
usdDraco: Support custom Draco install location.

### DIFF
--- a/build_scripts/build_usd.py
+++ b/build_scripts/build_usd.py
@@ -1179,6 +1179,9 @@ def InstallUSD(context, force, buildArgs):
 
         if context.buildDraco:
             extraArgs.append('-DPXR_BUILD_DRACO_PLUGIN=ON')
+            draco_root = (context.dracoLocation
+                          if context.dracoLocation else context.instDir)
+            extraArgs.append('-DDRACO_ROOT="{}"'.format(draco_root))
         else:
             extraArgs.append('-DPXR_BUILD_DRACO_PLUGIN=OFF')
 
@@ -1429,6 +1432,8 @@ subgroup.add_argument("--draco", dest="build_draco", action="store_true",
                       help="Build Draco plugin for USD")
 subgroup.add_argument("--no-draco", dest="build_draco", action="store_false",
                       help="Do not build Draco plugin for USD (default)")
+group.add_argument("--draco-location", type=str,
+                   help="Directory where Draco is installed.")
 
 group = parser.add_argument_group(title="MaterialX Plugin Options")
 subgroup = group.add_mutually_exclusive_group()
@@ -1569,6 +1574,8 @@ class InstallContext:
 
         # - Draco Plugin
         self.buildDraco = args.build_draco
+        self.dracoLocation = (os.path.abspath(args.draco_location)
+                                if args.draco_location else None)
 
         # - MaterialX Plugin
         self.buildMaterialX = args.build_materialx

--- a/cmake/modules/FindDraco.cmake
+++ b/cmake/modules/FindDraco.cmake
@@ -25,4 +25,5 @@
 # provides the result by defining variable DRACO_LIBRARY.
 #
 
-find_library(DRACO_LIBRARY draco.lib libdraco.a ${DRACO_ROOT})
+find_library(DRACO_LIBRARY draco PATHS ${DRACO_ROOT})
+find_path(DRACO_INCLUDES draco/compression/decode.h PATHS "${DRACO_ROOT}/src")

--- a/pxr/usd/plugin/usdDraco/CMakeLists.txt
+++ b/pxr/usd/plugin/usdDraco/CMakeLists.txt
@@ -17,6 +17,7 @@ pxr_plugin(${PXR_PACKAGE}
 
     INCLUDE_DIRS
         ${Boost_INCLUDE_DIRS}
+        ${DRACO_INCLUDES}
         ${PYTHON_INCLUDE_DIRS}
 
     CPPFILES


### PR DESCRIPTION
Hook up DRACO_ROOT in build_scripts/build_usd.py. Default is
instDir, but can be overridden via use of the --draco-location
argument to build_usd.

- Update cmake/modules/FindDraco.cmake to find both the library
  and the includes for the library.
- Update pxr/usd/plugin/usdDraco/CMakeLists.txt to pass the
  include path and the library.